### PR TITLE
Improve wave box plot chart on mobile

### DIFF
--- a/src/components/waveBoxPlotChart.js
+++ b/src/components/waveBoxPlotChart.js
@@ -2,22 +2,35 @@ import * as Plot from "npm:@observablehq/plot";
 import { rideBlue } from "./constants.js";
 
 export function waveBoxPlotChart(data, width) {
+  // Five horizontal boxes need real width for their whiskers to read - below
+  // mobile width there isn't enough of it, so flip to vertical boxes, which
+  // trade the width they don't have for the height a narrow screen does.
+  const mobile = width < 600;
+  const filtered = data.filter(d => d.assigned_wave_number != null && d.assigned_wave_number != "VIP");
+  // Fill the phone screen rather than following width - fall back to a
+  // width-based guess if window isn't available (e.g. during a static build).
+  const viewportHeight = typeof window !== "undefined" ? window.innerHeight : width * 1.5;
+
   return Plot.plot({
     width: width,
-    height: width * 0.33,
-    marginLeft: 50,
-    y: { label: null },
-    x: { grid: true, inset: 6 },
+    height: mobile ? viewportHeight * 0.9 : width * 0.33,
+    marginLeft: mobile ? undefined : 50,
+    x: mobile ? { label: null } : { grid: true, inset: 6 },
+    y: mobile ? { grid: true, inset: 6, label: "Ride Time (hours)" } : { label: null },
     marks: [
-      Plot.boxX(
-        data.filter(d => d.assigned_wave_number != null && d.assigned_wave_number != "VIP"),
-        {
-          x: "ride_time_finish_decimal",
-          y: "assigned_wave_number",
-          fill: rideBlue,
-          fillOpacity: 0.3,
-        }
-      ),
+      mobile
+        ? Plot.boxY(filtered, {
+            x: "assigned_wave_number",
+            y: "ride_time_finish_decimal",
+            fill: rideBlue,
+            fillOpacity: 0.3,
+          })
+        : Plot.boxX(filtered, {
+            x: "ride_time_finish_decimal",
+            y: "assigned_wave_number",
+            fill: rideBlue,
+            fillOpacity: 0.3,
+          }),
     ],
   });
 }


### PR DESCRIPTION
## Summary
Follow-up to #15 - improves `waveBoxPlotChart` specifically for mobile widths:

- Switches from a horizontal box-and-whisker (`Plot.boxX`, one row per wave) to a vertical one (`Plot.boxY`, one column per wave) below mobile width, since 5 horizontal boxes don't have room for their whiskers to read on a narrow screen.
- Sizes the chart to ~90% of the viewport height on mobile instead of a width-based ratio, so it fills the phone screen rather than staying width-proportional.
- Adds a y-axis title ("Ride Time (hours)") for the now-visible value axis on mobile.
- Drops the fixed left margin on mobile, letting Plot size it to the shorter numeric tick labels instead of the longer "Wave N" labels it was tuned for on desktop.

Desktop rendering is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)