### PR TITLE
Canvas-based rider paths chart for mobile performance testing

### DIFF
--- a/src/components/riderPathsCanvasChart.js
+++ b/src/components/riderPathsCanvasChart.js
@@ -1,0 +1,105 @@
+import * as d3 from "npm:d3";
+import { raceCheckpoints, checkpointMiles } from "./constants.js";
+
+const HEIGHT = 900;
+const MARGIN = { top: 30, right: 16, bottom: 10, left: 16 };
+
+// Same chart as riderPathsSingleChart (every rider's position at each
+// checkpoint, linked into a path) but drawn on a <canvas> instead of as SVG.
+// riderPathsSingleChart draws ~7 links per rider as individual SVG <path>
+// elements - at ~18k riders that's well over 100k DOM nodes, which is what
+// makes it slow. Canvas has no DOM cost per line: the whole background
+// layer is one beginPath()/stroke() call per rider, so it scales with
+// strokes issued rather than elements created.
+//
+// `stages` picks which checkpoints to plot and in what order - pass a
+// subset of raceCheckpoints to drop stages entirely (e.g. a two-point
+// start/finish "order swap" view, or skipping the rest stops), or the full
+// list for the granular view.
+// `equalWidth` spaces stages evenly instead of proportionally to their
+// actual mile marker - two checkpoints either side of a rest stop sit only
+// a mile apart, so proportional spacing squeezes them (and their tick
+// labels) into an unreadable sliver; equal spacing gives every stage the
+// same room regardless of how far apart it is in real miles.
+export function riderPathsCanvasChart(linkData, highlightedData, width, {
+  stages = raceCheckpoints,
+  equalWidth = false,
+} = {}) {
+  const height = HEIGHT;
+  const dpr = typeof window !== "undefined" ? (window.devicePixelRatio || 1) : 1;
+
+  const canvas = document.createElement("canvas");
+  canvas.width = width * dpr;
+  canvas.height = height * dpr;
+  canvas.style.width = `${width}px`;
+  canvas.style.height = `${height}px`;
+
+  const ctx = canvas.getContext("2d");
+  ctx.scale(dpr, dpr);
+
+  const xForStage = equalWidth
+    ? d3.scalePoint().domain(stages).range([MARGIN.left, width - MARGIN.right])
+    : (milesScale => cp => milesScale(checkpointMiles[cp]))(
+        d3.scaleLinear().domain([0, 100]).range([MARGIN.left, width - MARGIN.right])
+      );
+
+  const segments = stages.slice(0, -1).map((cp, i) => [cp, stages[i + 1]]);
+
+  // Rider position values span every plotted checkpoint, not just start/finish.
+  const allPositions = linkData.flatMap(d => stages.map(cp => +d[cp]).filter(v => !Number.isNaN(v)));
+  const y = d3.scaleLinear()
+    .domain(d3.extent(allPositions))
+    .range([MARGIN.top, height - MARGIN.bottom]); // min -> top, matching Plot's y.reverse: true
+
+  // One beginPath()/stroke() per *rider* (not one giant path for everyone).
+  // Canvas only applies alpha once per stroke() call - batching every rider
+  // into a single path made the whole thing paint as one flat grey shape
+  // instead of overlapping strokes compounding, which is what gave the SVG
+  // version its "web" of darker, more-crossed-over regions. Stroking each
+  // rider separately keeps that layering while still being one draw call
+  // per rider rather than one DOM element per segment.
+  const strokePaths = (ctx, data) => {
+    for (const d of data) {
+      ctx.beginPath();
+      let drew = false;
+      for (const [cpA, cpB] of segments) {
+        const yA = +d[cpA], yB = +d[cpB];
+        if (Number.isNaN(yA) || Number.isNaN(yB)) continue;
+        // moveTo per segment (not just once) so a missing checkpoint in the
+        // middle leaves a gap instead of drawing a stray connecting line.
+        ctx.moveTo(xForStage(cpA), y(yA));
+        ctx.lineTo(xForStage(cpB), y(yB));
+        drew = true;
+      }
+      if (drew) ctx.stroke();
+    }
+  };
+
+  // Background: every rider, thin and faint.
+  ctx.lineWidth = 0.16;
+  ctx.strokeStyle = "rgba(0,0,0,0.2)";
+  strokePaths(ctx, linkData);
+
+  // Highlighted rider(s), solid, on top.
+  ctx.lineWidth = 1.5;
+  ctx.strokeStyle = "tomato";
+  strokePaths(ctx, highlightedData);
+
+  // Mile ticks along the top, mirroring the original's `axis: "top"`.
+  ctx.font = "10px system-ui, sans-serif";
+  ctx.fillStyle = "#555";
+  ctx.strokeStyle = "rgba(0,0,0,0.1)";
+  ctx.lineWidth = 1;
+  ctx.textAlign = "center";
+  ctx.textBaseline = "bottom";
+  for (const cp of stages) {
+    const tx = xForStage(cp);
+    ctx.beginPath();
+    ctx.moveTo(tx, MARGIN.top);
+    ctx.lineTo(tx, height - MARGIN.bottom);
+    ctx.stroke();
+    ctx.fillText(`${checkpointMiles[cp]}mi`, tx, MARGIN.top - 4);
+  }
+
+  return canvas;
+}

--- a/src/ride_london_prod.md
+++ b/src/ride_london_prod.md
@@ -96,6 +96,7 @@ import { waveChordChart } from "./components/waveChordChart.js";
 import { raceSimGraph, withRestStops } from "./components/raceSimGraph.js";
 import { riderPathsSingleChart } from "./components/riderPathsSingleChart.js";
 import { riderPathsSimplifiedChart } from "./components/riderPathsSimplifiedChart.js";
+import { riderPathsCanvasChart } from "./components/riderPathsCanvasChart.js";
 import { yearHistogramsChart } from "./components/yearHistogramsChart.js";
 import { introRouteMap } from "./components/introRouteMap.js";
 import { silvertonRouteMap } from "./components/silvertonRouteMap.js";
@@ -769,6 +770,40 @@ display(restStopAvgTable(restStopStats))
 ```js
   const linkData = raceData_2024_100
   const highlightedData = raceData_2024_100.filter(d => d.rider_no == 126410)
+```
+
+## Did congestion make the race more dangerous? (canvas trial)
+
+Same chart as the commented-out `riderPathsSingleChart` below - every rider's position at each checkpoint, linked into a path - but drawn on a `<canvas>` with D3 scales instead of as ~126,000 individual SVG `<path>` elements, to see whether that's meaningfully faster to render.
+
+```js
+display(riderPathsCanvasChart(linkData, highlightedData, width))
+```
+
+### The big overall order swap (canvas trial)
+
+The same idea as above, but collapsed down to just start position vs. finish position - the canvas version of the old `riderPathsSimplifiedChart`.
+
+```js
+display(riderPathsCanvasChart(linkData, highlightedData, width / 4, { stages: ["rider_pos_start", "rider_pos_finish"] }))
+```
+
+### Exploration: equal-width stages
+
+Right now each stage's width is proportional to the actual miles between checkpoints, which squeezes the three rest stops (only a mile apart each) into an unreadable sliver - their tick labels even overlap ("2526mi", "5354mi", "7374mi"). Spacing every stage equally instead should make the passing that happens *during* a rest stop much easier to see.
+
+```js
+display(riderPathsCanvasChart(linkData, highlightedData, width, { equalWidth: true }))
+```
+
+### Exploration: without the rest stops
+
+The other option - drop the rest-stop checkpoints entirely and only plot the four distance-covering stages (start → 25 → 53 → 73 → finish), so the chart shows pure race-distance progression with none of the stop-related churn.
+
+```js
+display(riderPathsCanvasChart(linkData, highlightedData, width, {
+  stages: ["rider_pos_start", "rider_pos_25", "rider_pos_53", "rider_pos_73", "rider_pos_finish"],
+}))
 ```
 
 <!-- ## Did congestion make the race more dangerous?


### PR DESCRIPTION
## Summary
Trials a canvas/D3 rewrite of `riderPathsSingleChart` (the rider-order-swap chart, currently commented out on the page) to see whether it's meaningfully faster on lower-powered devices than the original Plot/SVG version.

- `riderPathsSingleChart` draws ~7 links per rider as individual SVG `<path>` elements - at ~18k riders that's 100k+ DOM nodes, which is what makes it slow to render.
- `riderPathsCanvasChart` does the same math (D3 scales, same reversed-position logic as Plot's `reverse: true`) but strokes each rider as one `beginPath()`/`stroke()` call on a `<canvas>` - no DOM cost per line, and alpha still compounds across overlapping riders the same way the separate SVG elements did.

Added live to the page (not commented out) so it's easy to open on a phone and compare:
- the full 7-stage chart (equivalent to the original)
- a collapsed start-vs-finish "order swap" view (canvas equivalent of `riderPathsSimplifiedChart`)
- two exploration variants for seeing the rest-stop passing more clearly: one with all stages spaced equally instead of proportional-to-miles (the three rest stops are only a mile apart each and get squeezed into a sliver otherwise), and one with the rest-stop checkpoints dropped entirely

Nothing here is finalised - it's meant for testing before deciding which view(s), if any, replace the commented-out original.

🤖 Generated with [Claude Code](https://claude.com/claude-code)